### PR TITLE
Simply use `setlocale` to initialize the locale

### DIFF
--- a/lib/ffi-locale.rb
+++ b/lib/ffi-locale.rb
@@ -2,7 +2,4 @@ require 'ffi'
 require 'ffi-locale/ffi-locale.rb'
 
 # Setup locale from environment when first loaded.
-# See http://pubs.opengroup.org/onlinepubs/007908799/xbd/envvar.html#tag_002_002
-ENV.select { |key, value| key =~ /^LC_/ }.each do |key, value|
-  FFILocale::setlocale FFILocale.const_get(key), value
-end
+FFILocale::setlocale FFILocale.const_get("LC_ALL"), ""


### PR DESCRIPTION
There is a bit more logic involved despite inspecting the LC_* variables:

```
If locale is an empty string, "", each part of the locale that should be modified is set according to the  environment  variables.   The
       details are implementation-dependent.  For glibc, first (regardless of category), the environment variable LC_ALL is inspected, next the
       environment variable with the same name as the category (see the table above), and finally the environment  variable  LANG.   The  first
       existing  environment  variable  is  used.   If  its value is not a valid locale specification, the locale is unchanged, and setlocale()
       returns NULL.
```
For instance, I have only LANG set, which should also be taken into account but currently is not.